### PR TITLE
Fix getconfig

### DIFF
--- a/commands/misc.go
+++ b/commands/misc.go
@@ -88,12 +88,12 @@ func (c *Commands) handleGetConfig(s *discordgo.Session, m *discordgo.MessageCre
 
 	msg := ""
 
-	rt := reflect.TypeOf(c.Config)
+	rt := reflect.TypeOf(*c.Config)
 	for i := 0; i < rt.NumField(); i++ {
 		x := rt.Field(i)
 		tagVal := strings.Split(x.Tag.Get("json"), ",")[0]
 		tagName := x.Name
-		prop := reflect.ValueOf(&c.Config).Elem().FieldByName(tagName)
+		prop := reflect.ValueOf(c.Config).Elem().FieldByName(tagName)
 
 		if configKey == "all" {
 			switch prop.Interface().(type) {


### PR DESCRIPTION
`reflect.TypeOf()` was expecting a value (pointer given)
 - solution: `c.Config` is now dereferenced in call to `TypeOf()`

`reflect.ValueOf()` was expecting a pointer (pointer to pointer given)
 - solution: `c.Config` passed as-is since it was already a pointer

